### PR TITLE
Fix file paths so tests run using npm test.

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 var test = require('tape'),
     fs = require('fs'),
+    path = require('path'),
     Backbone = require('backbone'),
     underTest = require('../index');
 
@@ -19,56 +20,76 @@ function createInstanceFromSource(originalSource) {
 test('should call cacheable', function (t) {
     t.plan(1);
 
-    fs.readFile('Test.Model.with.no.constructor.txt', {encoding: 'UTF-8'}, function (err, data) {
-        if (err) throw err;
-
-        createInstanceFromSource(data);
-        t.ok(context.cacheableCalled);
-    });
+    fs.readFile(
+        path.join(__dirname, 'Test.Model.with.no.constructor.txt'),
+        { encoding: 'utf-8' },
+        function (err, data) {
+            if (err) throw err;
+            
+            createInstanceFromSource(data);
+            t.ok(context.cacheableCalled);
+        }
+    );
 });
 
 test('should do nothing if a module already has a constructor', function (t) {
     t.plan(1);
 
-    fs.readFile('Test.Model.with.constructor.txt', { encoding: 'UTF-8' }, function (err, data) {
-        if (err) throw err;
-
-        var instance = createInstanceFromSource(data);
-        t.equal(instance.constructor.name, '');
-    });
+    fs.readFile(
+        path.join(__dirname, 'Test.Model.with.constructor.txt'),
+        { encoding: 'utf-8' },
+        function (err, data) {
+            if (err) throw err;
+            
+            var instance = createInstanceFromSource(data);
+            t.equal(instance.constructor.name, '');
+        }
+    );
 });
 
 test('should add named constructor based on the response path', function (t) {
     t.plan(1);
 
-    fs.readFile('Test.Model.with.no.constructor.txt', { encoding: 'UTF-8' }, function (err, data) {
-        if (err) throw err;
-
-        var instance = createInstanceFromSource(data);
-        t.equal(instance.constructor.name, 'SimpleModel');
-    });
+    fs.readFile(
+        path.join(__dirname, 'Test.Model.with.no.constructor.txt'),
+        { encoding: 'utf-8' },
+        function (err, data) {
+            if (err) throw err;
+            
+            var instance = createInstanceFromSource(data);
+            t.equal(instance.constructor.name, 'SimpleModel');
+        }
+    );
 });
 
 test('should handle resource names with dots in them', function (t) {
     t.plan(1);
 
-    fs.readFile('Test.Model.with.no.constructor.txt', { encoding: 'UTF-8' }, function (err, data) {
-        if (err) throw err;
+    fs.readFile(
+        path.join(__dirname, 'Test.Model.with.no.constructor.txt'),
+        { encoding: 'utf-8' },
+        function (err, data) {
+            if (err) throw err;
 
-        context.resourcePath = '/a/random/path/simple.module.with.dots.js'
-        var instance = createInstanceFromSource(data);
-        t.equal(instance.constructor.name, 'SimpleModuleWithDots');
-    });
+            context.resourcePath = '/a/random/path/simple.module.with.dots.js'
+            var instance = createInstanceFromSource(data);
+            t.equal(instance.constructor.name, 'SimpleModuleWithDots');
+        }
+    );
 });
 
 test('should handle resource names with dashs in them', function (t) {
     t.plan(1);
 
-    fs.readFile('Test.Model.with.no.constructor.txt', { encoding: 'UTF-8' }, function (err, data) {
-        if (err) throw err;
+    fs.readFile(
+        path.join(__dirname, 'Test.Model.with.no.constructor.txt'),
+        { encoding: 'utf-8' },
+        function (err, data) {
+            if (err) throw err;
 
-        context.resourcePath = '/a/random/path/simple-Module-With-dashs.js'
-        var instance = createInstanceFromSource(data);
-        t.equal(instance.constructor.name, 'SimpleModuleWithDashs');
-    });
+            context.resourcePath = '/a/random/path/simple-Module-With-dashs.js'
+            var instance = createInstanceFromSource(data);
+            t.equal(instance.constructor.name, 'SimpleModuleWithDashs');
+        }
+    );
 });


### PR DESCRIPTION
Running `npm test` from the root dir results in the fixtures not being found:

```
> named-backbone-loader@0.1.0 test /Users/tane/sites/backbone-namedconstructor-loader
> tape test/*.js

TAP version 13
# should call cacheable
/Users/tane/sites/backbone-namedconstructor-loader/test/index.test.js:23
        if (err) throw err;
                       ^
Error: ENOENT, open 'Test.Model.with.no.constructor.txt'
    at Error (native)
npm ERR! Test failed.  See above for more details.
```

This patch uses the `path` module to ensure the fixtures get read correctly.
